### PR TITLE
[AT-50] Exam listing UI

### DIFF
--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Login from "./pages/login";
 import Questions from "./pages/questions";
+import ExamList from "./pages/exam-list";
 import { AuthContextProvider } from "../../AuthContext";
 import styles from "./base.scss";
 
@@ -15,6 +16,7 @@ const App = () => {
 					<Routes>
 						<Route path='/' element={<Login />} />
 						<Route path='/questions' element={<Questions />} />
+						<Route path='/exams' element={<ExamList />} />
 					</Routes>
 				</Router>
 			</AuthContextProvider>

--- a/src/components/app/pages/exam-list/index.tsx
+++ b/src/components/app/pages/exam-list/index.tsx
@@ -1,15 +1,26 @@
 /** @format */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Page from "../page";
 import styles from "./styles.scss";
 import ExamTile from "../../../exam-tile";
 import { useNavigate } from "react-router-dom";
+import { Exam, getPartialExams } from "../../../../model/Exam";
 
 const ExamList = () => {
 	const navigate = useNavigate();
+	const [exams, setExams] = useState<Exam[]>();
+	useEffect(() => {
+		getPartialExams()
+			.then((x) => setExams(x))
+			.catch(() => console.error("error fetching exams"));
+	}, []);
 
-	const onClick = () => {
+	const navigateToExam = () => {
 		navigate("/questions");
+	};
+
+	const addExam = () => {
+		alert("add exam");
 	};
 
 	return (
@@ -25,8 +36,15 @@ const ExamList = () => {
 				<div className={styles.headerBorder} />
 			</div>
 			<div className={styles.examBackground}>
+				{exams?.map((x) => {
+					return (
+						<div className={styles.examsBox} key={x.id}>
+							<ExamTile onClick={navigateToExam} name={x.name} />
+						</div>
+					);
+				})}
 				<div className={styles.examsBox}>
-					<ExamTile onClick={onClick} />
+					<ExamTile onClick={addExam} name={"Add New Exam"} addExam />
 				</div>
 			</div>
 		</Page>

--- a/src/components/app/pages/exam-list/index.tsx
+++ b/src/components/app/pages/exam-list/index.tsx
@@ -1,0 +1,36 @@
+/** @format */
+import React, { useState } from "react";
+import Page from "../page";
+import styles from "./styles.scss";
+import ExamTile from "../../../exam-tile";
+import { useNavigate } from "react-router-dom";
+
+const ExamList = () => {
+	const navigate = useNavigate();
+
+	const onClick = () => {
+		navigate("/questions");
+	};
+
+	return (
+		<Page>
+			<div className={styles.header}>
+				<div className={styles.logo}>
+					<div className={styles.athleti}>Athleti</div>
+					<div className={styles.train}>Train</div>
+					<div className={styles.whitworth}>
+						by Whitworth University
+					</div>
+				</div>
+				<div className={styles.headerBorder} />
+			</div>
+			<div className={styles.examBackground}>
+				<div className={styles.examsBox}>
+					<ExamTile onClick={onClick} />
+				</div>
+			</div>
+		</Page>
+	);
+};
+
+export default ExamList;

--- a/src/components/app/pages/exam-list/styles.scss
+++ b/src/components/app/pages/exam-list/styles.scss
@@ -1,0 +1,83 @@
+/** @format */
+
+@use "../../../../styles/variables" as variables;
+
+@mixin flexRow {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: row;
+}
+
+.background {
+	background-color: #f5f5f5;
+}
+
+.header {
+	width: 100vw;
+	max-height: 10%;
+
+	.logo {
+		position: absolute;
+		margin-left: 10px;
+		top: 0;
+
+		display: flex;
+		justify-content: flex-start;
+		align-items: flex-start;
+	}
+
+	.athleti {
+		font-weight: 800;
+		font-size: 48px;
+		text-decoration-line: underline;
+
+		color: #0158ae;
+	}
+
+	.train {
+		font-weight: 800;
+		font-size: 48px;
+		margin-left: 6px;
+	}
+
+	.whitworth {
+		margin-top: 33px;
+
+		font-weight: 800;
+		font-size: 18px;
+		margin-left: 10px;
+	}
+
+	.headerBorder {
+		position: absolute;
+		width: 100%;
+		height: 10px;
+		left: 0;
+		top: 70px;
+
+		background: #c4c4c4;
+	}
+}
+
+.examBackground {
+	@include flexRow;
+	background-color: #f5f5f5;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	.examsBox {
+		width: 20%;
+		height: 40%;
+		background-color: #ffffff;
+		filter: drop-shadow(0.1rem 0.1rem 0.2rem rgba(0, 0, 0, 0.5));
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-direction: column;
+		position: relative;
+	}
+}

--- a/src/components/app/pages/exam-list/styles.scss
+++ b/src/components/app/pages/exam-list/styles.scss
@@ -15,7 +15,7 @@
 
 .header {
 	width: 100vw;
-	max-height: 10%;
+	height: 10%;
 
 	.logo {
 		position: absolute;
@@ -68,6 +68,8 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	position: relative;
+	flex-wrap: wrap;
 
 	.examsBox {
 		width: 20%;
@@ -79,5 +81,7 @@
 		align-items: center;
 		flex-direction: column;
 		position: relative;
+		margin-right: 20px;
+		margin-left: 20px;
 	}
 }

--- a/src/components/auth-widget/index.tsx
+++ b/src/components/auth-widget/index.tsx
@@ -22,7 +22,7 @@ const AuthWidget = () => {
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
 	const { login, register } = useAuth();
-	const path = "/questions";
+	const path = "/exams";
 	const navigate = useNavigate();
 
 	const onClickLogin = () => {

--- a/src/components/exam-tile/index.tsx
+++ b/src/components/exam-tile/index.tsx
@@ -5,14 +5,25 @@ import styles from "./styles.scss";
 
 interface ExamTileProps {
 	onClick: () => void;
+	name: string;
+	addExam?: boolean;
 }
 
-const ExamTile: React.FunctionComponent<ExamTileProps> = ({ onClick }) => {
+const ExamTile: React.FunctionComponent<ExamTileProps> = ({
+	onClick,
+	name,
+	addExam,
+}) => {
 	return (
 		<div className={styles.examTile}>
 			<div className={styles.buttonBox}>
-				<button className={styles.examButton} onClick={onClick}>
-					Exam Name
+				<button
+					className={
+						addExam ? styles.addExamButton : styles.examButton
+					}
+					onClick={onClick}
+				>
+					{name}
 				</button>
 			</div>
 		</div>

--- a/src/components/exam-tile/index.tsx
+++ b/src/components/exam-tile/index.tsx
@@ -1,0 +1,22 @@
+/** @format */
+
+import React from "react";
+import styles from "./styles.scss";
+
+interface ExamTileProps {
+	onClick: () => void;
+}
+
+const ExamTile: React.FunctionComponent<ExamTileProps> = ({ onClick }) => {
+	return (
+		<div className={styles.examTile}>
+			<div className={styles.buttonBox}>
+				<button className={styles.examButton} onClick={onClick}>
+					Exam Name
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default ExamTile;

--- a/src/components/exam-tile/styles.scss
+++ b/src/components/exam-tile/styles.scss
@@ -1,0 +1,36 @@
+/** @format */
+@use "../../styles/variables" as variables;
+
+@mixin flexColumn {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
+}
+
+@mixin button {
+	width: 80%;
+	height: 40px;
+	margin-bottom: 10px;
+	border: none;
+	color: #c4c4c4;
+	cursor: pointer;
+}
+
+.examTile {
+	@include flexColumn;
+	width: 100%;
+	height: 100%;
+
+	.buttonBox {
+		@include flexColumn;
+
+		width: 80%;
+	}
+
+	.examButton {
+		@include button;
+
+		background-color: #1b43ef;
+	}
+}

--- a/src/components/exam-tile/styles.scss
+++ b/src/components/exam-tile/styles.scss
@@ -33,4 +33,10 @@
 
 		background-color: #1b43ef;
 	}
+
+	.addExamButton {
+		@include button;
+
+		background-color: #fd8606;
+	}
 }


### PR DESCRIPTION
Frond End design of the page where exams are listed. Exam names are pulled from firebase and displayed nicely on tiles. Additionally, there is an add exam button that is currently non functional until the UI is created in [AT-29]

[AT-29]: https://exam-prep.atlassian.net/browse/AT-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ